### PR TITLE
Updated static-toolbox-nmap-x86

### DIFF
--- a/recipes/nmap/linux_x86/Dockerfile
+++ b/recipes/nmap/linux_x86/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get update && \
         wget \
         git \
         pkg-config \
-        python
+        python \
+        flex \
+        bison
 RUN mkdir /build
 ADD . /build
 RUN chmod +x /build/build_x86.sh

--- a/recipes/nmap/linux_x86/build_x86.sh
+++ b/recipes/nmap/linux_x86/build_x86.sh
@@ -6,8 +6,7 @@ NMAP_COMMIT=
 
 fetch(){
     if [ ! -d "/build/musl" ];then
-        #git clone https://github.com/GregorR/musl-cross.git /build/musl
-        git clone https://github.com/takeshixx/musl-cross.git /build/musl
+        git clone https://github.com/GregorR/musl-cross.git /build/musl
     fi
     if [ ! -d "/build/openssl" ];then
         git clone https://github.com/drwetter/openssl-pm-snapshot.git /build/openssl


### PR DESCRIPTION
1. Takeshixx/musl-cross repo no longer exists. Changed script back to use GregorR/musl-cross repo.
2. libpcap requires flex & bison to compile. Added flex & bison to Dockerfile.