### PR TITLE
Fix deprecated set-output

### DIFF
--- a/.github/workflows/build-nmap.yml
+++ b/.github/workflows/build-nmap.yml
@@ -151,12 +151,12 @@ jobs:
             git fetch --quiet --prune --tags
             if [[ $(git tag -l | grep nmap-v${{ needs.build-x86.outputs.version }} | wc -l) -gt 0 ]]; then
               echo "Tag for nmap-v${{ needs.build-x86.outputs.version }} already exists. Skipping release creation."
-              echo ::set-output name=NEW_RELEASE::"false"
+              echo "NEW_RELEASE=false" >> $GITHUB_OUTPUT
             else
               echo "Tag for nmap-v${{ needs.build-x86.outputs.version }} missing. Starting release creation."
               git tag "nmap-v${{ needs.build-x86.outputs.version }}"
               git push origin "nmap-v${{ needs.build-x86.outputs.version }}"
-              echo ::set-output name=NEW_RELEASE::"true"
+              echo "NEW_RELEASE=true" >> $GITHUB_OUTPUT
             fi
 
         - name: Create Release

--- a/.github/workflows/build-openssh.yml
+++ b/.github/workflows/build-openssh.yml
@@ -113,11 +113,11 @@ jobs:
             set +e
             if git rev-list "openssh-v${{ needs.build-x86.outputs.version }}".. >/dev/null;then
               echo "Tag for openssh-v${{ needs.build-x86.outputs.version }} already exists. Skipping release creation."
-              echo ::set-output name=NEW_RELEASE::"false"
+              echo "NEW_RELEASE=false" >> $GITHUB_OUTPUT
             else
               git tag "openssh-v${{ needs.build-x86.outputs.version }}"
               git push origin "openssh-v${{ needs.build-x86.outputs.version }}"
-              echo ::set-output name=NEW_RELEASE::"true"
+              echo "NEW_RELEASE=true" >> $GITHUB_OUTPUT
             fi
 
         - name: Create Release

--- a/.github/workflows/build-socat.yml
+++ b/.github/workflows/build-socat.yml
@@ -141,11 +141,11 @@ jobs:
             set +e
             if git rev-list "socat-v${{ needs.build-x86.outputs.version }}".. >/dev/null;then
               echo "Tag for socat-v${{ needs.build-x86.outputs.version }} already exists. Skipping release creation."
-              echo ::set-output name=NEW_RELEASE::"false"
+              echo "NEW_RELEASE=false" >> $GITHUB_OUTPUT
             else
               git tag "socat-v${{ needs.build-x86.outputs.version }}"
               git push origin "socat-v${{ needs.build-x86.outputs.version }}"
-              echo ::set-output name=NEW_RELEASE::"true"
+              echo "NEW_RELEASE=true" >> $GITHUB_OUTPUT
             fi
 
         - name: Create Release

--- a/.github/workflows/build-tcpdump.yml
+++ b/.github/workflows/build-tcpdump.yml
@@ -112,11 +112,11 @@ jobs:
             set +e
             if git rev-list "tcpdump-v${{ needs.build-x86.outputs.version }}".. >/dev/null;then
               echo "Tag for tcpdump-v${{ needs.build-x86.outputs.version }} already exists. Skipping release creation."
-              echo ::set-output name=NEW_RELEASE::"false"
+              echo "NEW_RELEASE=false" >> $GITHUB_OUTPUT
             else
               git tag "tcpdump-v${{ needs.build-x86.outputs.version }}"
               git push origin "tcpdump-v${{ needs.build-x86.outputs.version }}"
-              echo ::set-output name=NEW_RELEASE::"true"
+              echo "NEW_RELEASE=true" >> $GITHUB_OUTPUT
             fi
 
         - name: Create Release

--- a/build/targets/build_gdb.sh
+++ b/build/targets/build_gdb.sh
@@ -51,9 +51,9 @@ main() {
     cp "${BUILD_DIRECTORY}/gdb_build/gdbserver/gdbserver" "${OUTPUT_DIRECTORY}/gdbserver${GDBSERVER_VERSION}"
     echo "[+] Finished building GDB ${CURRENT_ARCH}"
 
-    echo ::set-output name=PACKAGED_NAME::"gdb${GDB_VERSION}"
-    echo ::set-output name=PACKAGED_NAME_PATH::"/output/*"
-    echo ::set-output name=PACKAGED_VERSION::"${version_number}"
+    echo "PACKAGED_NAME=gdb${GDB_VERSION}" >> $GITHUB_OUTPUT
+    echo "PACKAGED_NAME_PATH=/output/*" >> $GITHUB_OUTPUT
+    echo "PACKAGED_VERSION=${version_number}" >> $GITHUB_OUTPUT
 }
 
 main

--- a/build/targets/build_openssh.sh
+++ b/build/targets/build_openssh.sh
@@ -49,9 +49,9 @@ main() {
     echo "[+] Finished building OpenSSH ${CURRENT_ARCH}"
 
     OPENSSH_VERSION=$(echo $OPENSSH_VERSION | sed 's/-//')
-    echo ::set-output name=PACKAGED_NAME::"${OPENSSH_VERSION}"
-    echo ::set-output name=PACKAGED_NAME_PATH::"/output/*"
-    echo ::set-output name=PACKAGED_VERSION::"${version_number}"
+    echo "PACKAGED_NAME=${OPENSSH_VERSION} >> $GITHUB_OUTPUT"
+    echo "PACKAGED_NAME_PATH=/output/* >> $GITHUB_OUTPUT"
+    echo "PACKAGED_VERSION=${version_number} >> $GITHUB_OUTPUT"
 }
 
 main

--- a/build/targets/build_socat.sh
+++ b/build/targets/build_socat.sh
@@ -41,9 +41,9 @@ main() {
     cp "${BUILD_DIRECTORY}/socat/socat" "${OUTPUT_DIRECTORY}/socat${version}"
     echo "[+] Finished building socat ${CURRENT_ARCH}"
 
-    echo ::set-output name=PACKAGED_NAME::"socat${version}"
-    echo ::set-output name=PACKAGED_NAME_PATH::"${OUTPUT_DIRECTORY}/*"
-    echo ::set-output name=PACKAGED_VERSION::"${version_number}"
+    echo "PACKAGED_NAME=socat${version}" >> $GITHUB_OUTPUT
+    echo "PACKAGED_NAME_PATH=${OUTPUT_DIRECTORY}/*" >> $GITHUB_OUTPUT
+    echo "PACKAGED_VERSION=${version_number}" >> $GITHUB_OUTPUT
 }
 
 main

--- a/build/targets/build_strace.sh
+++ b/build/targets/build_strace.sh
@@ -36,8 +36,8 @@ main() {
     cp "${BUILD_DIRECTORY}/strace/strace" "${OUTPUT_DIRECTORY}/strace"
     echo "[+] Finished building strace ${CURRENT_ARCH}"
 
-    echo ::set-output name=PACKAGED_NAME::"strace${version}"
-    echo ::set-output name=PACKAGED_NAME_PATH::"${OUTPUT_DIRECTORY}/*"
+    echo "PACKAGED_NAME=strace${version}" >> $GITHUB_OUTPUT
+    echo "PACKAGED_NAME_PATH=${OUTPUT_DIRECTORY}/*" >> $GITHUB_OUTPUT
 }
 
 main

--- a/build/targets/build_tcpdump.sh
+++ b/build/targets/build_tcpdump.sh
@@ -39,9 +39,9 @@ main() {
     cp "${BUILD_DIRECTORY}/tcpdump/tcpdump" "${OUTPUT_DIRECTORY}/tcpdump${version}"
     echo "[+] Finished building tcpdump ${CURRENT_ARCH}"
 
-    echo ::set-output name=PACKAGED_NAME::"tcpdump${version}"
-    echo ::set-output name=PACKAGED_NAME_PATH::"${OUTPUT_DIRECTORY}/*"
-    echo ::set-output name=PACKAGED_VERSION::"${version_number}"
+    echo "PACKAGED_NAME=tcpdump${version}" >> $GITHUB_OUTPUT
+    echo "PACKAGED_NAME_PATH=${OUTPUT_DIRECTORY}/*" >> $GITHUB_OUTPUT
+    echo "PACKAGED_VERSION=${version_number}" >> $GITHUB_OUTPUT
 }
 
 main

--- a/build/targets/build_tcpreplay.sh
+++ b/build/targets/build_tcpreplay.sh
@@ -50,8 +50,8 @@ main() {
     cp "${BUILD_DIRECTORY}/tcpreplay/tcpreplay" "${OUTPUT_DIRECTORY}/tcpreplay"
     echo "[+] Finished building tcpreplay ${CURRENT_ARCH}"
 
-    echo ::set-output name=PACKAGED_NAME::"tcpreplay${version}"
-    echo ::set-output name=PACKAGED_NAME_PATH::"${OUTPUT_DIRECTORY}/*"
+    echo "PACKAGED_NAME=tcpreplay${version}"
+    echo "PACKAGED_NAME_PATH=${OUTPUT_DIRECTORY}/*"
 }
 
 main

--- a/package/targets/nmap/package.sh
+++ b/package/targets/nmap/package.sh
@@ -53,13 +53,13 @@ cd "$tmp_dir"
 TARBALL="nmap-${version}-${arch}-portable.tar.gz"
 tar czf "${output}/${TARBALL}" -C "$tmp_dir" .
 cp "${output}/${TARBALL}" /packaged
-echo ::set-output name=PACKAGED_TARBALL::${TARBALL}
-echo ::set-output name=PACKAGED_TARBALL_PATH::"/packaged/${TARBALL}"
+echo "PACKAGED_TARBALL=${TARBALL}" >> $GITHUB_OUTPUT
+echo "PACKAGED_TARBALL_PATH=/packaged/${TARBALL}"  >> $GITHUB_OUTPUT
 
 ZIP="nmap-${version}-${arch}-portable.zip"
 zip -r -q "${output}/${ZIP}" .
 cp "${output}/${ZIP}" /packaged
-echo ::set-output name=PACKAGED_ZIP::${ZIP}
-echo ::set-output name=PACKAGED_ZIP_PATH::"/packaged/${ZIP}"
+echo "PACKAGED_ZIP=${ZIP}" >> $GITHUB_OUTPUT
+echo "PACKAGED_ZIP_PATH=/packaged/${ZIP}" >> $GITHUB_OUTPUT
 
-echo ::set-output name=PACKAGED_VERSION::${version}
+echo "PACKAGED_VERSION=${version}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub [is deprecating `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

This PR replaces the occurrences with the new `$GITHUB_OUTPUT` environment files.