### PR TITLE
Add --enable-openssl-method to socat build configuration

### DIFF
--- a/build/targets/build_socat.sh
+++ b/build/targets/build_socat.sh
@@ -24,6 +24,7 @@ build_socat() {
         CPPFLAGS="-I${BUILD_DIRECTORY} -I${BUILD_DIRECTORY}/openssl/include -DNETDB_INTERNAL=-1" \
         LDFLAGS="-L${BUILD_DIRECTORY}/readline -L${BUILD_DIRECTORY}/ncurses/lib -L${BUILD_DIRECTORY}/openssl" \
         ./configure \
+            --enable-openssl-method \
             --host="$(get_host_triple)"
     make -j4
     strip socat


### PR DESCRIPTION
Socat has deprectated the use of the openssl-method option to choose which version of SSL/TLS to use.
The intended replacement is openssl-min-proto-version and openssl-max-proto-version, but it's not available with openssl 1.0.2 (and probably don't support old ssl versions)

With this config flag, we can enable again the openssl-method option to choose which SSL / TLS version to use.

It's obviously deprecated/insecure (especially with old methods), just like openssl-pm-snapshot.